### PR TITLE
feat: adding react error boundary

### DIFF
--- a/template_content/src/components/ErrorBoundary.tsx
+++ b/template_content/src/components/ErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import React, { ErrorInfo, ReactNode } from 'react'
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+  fallback: ReactNode
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+}
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(_: Error): ErrorBoundaryState {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Example "componentStack":
+    //   in ComponentThatThrows (created by App)
+    //   in ErrorBoundary (created by App)
+    //   in div (created by App)
+    //   in App
+    // logErrorToMyService(error, info.componentStack)
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return this.props.fallback
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/template_content/src/components/ErrorFallback.tsx
+++ b/template_content/src/components/ErrorFallback.tsx
@@ -1,0 +1,17 @@
+const ErrorFallback = () => {
+  return (
+    <div className="hero min-h-screen bg-teal-400">
+      <div className="hero-content text-center rounded-lg p-6 max-w-md bg-white mx-auto">
+        <div className="max-w-md">
+          <h1 className="text-4xl">Error occured</h1>
+          <p className="py-6">
+            Please make sure to set up your environment variables correctly. Create a .env file based on .env.template and fill in the
+            required values. This controls the network and credentials for connections with Algod and Indexer.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ErrorFallback

--- a/template_content/src/main.tsx.jinja
+++ b/template_content/src/main.tsx.jinja
@@ -6,10 +6,13 @@ import './styles/main.css'
 {% elif use_tailwind == false -%}
 import './styles/App.css'
 {% endif -%}
-
+import ErrorBoundary from './components/ErrorBoundary'
+import ErrorFallback from './components/ErrorFallback'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary fallback={<ErrorFallback />}>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>,
 )

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -51,6 +51,9 @@ def working_dir() -> Iterator[Path]:
         yield working_dir
 
         for src_dir in working_generated_root.iterdir():
+            if not src_dir.is_dir():
+                continue
+
             dest_dir = generated_root / src_dir.stem
             shutil.rmtree(dest_dir, ignore_errors=True)
             shutil.copytree(src_dir, dest_dir, dirs_exist_ok=True)

--- a/tests_generated/test_all_default_parameters_off/package-lock.json
+++ b/tests_generated/test_all_default_parameters_off/package-lock.json
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/@algorandfoundation/algokit-utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-utils/-/algokit-utils-2.2.0.tgz",
-      "integrity": "sha512-xyvCjWhKNyC9uX90k2mEeqdpqWjs4o4/BnHMADaUNbqCGzghm33a3aqog+UlVqjpbpqqVNpneyPz0DlwxECpUQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-utils/-/algokit-utils-2.2.1.tgz",
+      "integrity": "sha512-LK6qm8YCDEKN5SSHLWoWB9u00LlQk4KgKm9wIRcctfP1y2up6zGLhsBYg4CDHqHe4TThg6wa/KYl7hpVlOqRSA==",
       "dependencies": {
         "algosdk": "^2.3.0",
         "algosdk2-2": "npm:algosdk@2.2.0",

--- a/tests_generated/test_all_default_parameters_off/src/components/ErrorBoundary.tsx
+++ b/tests_generated/test_all_default_parameters_off/src/components/ErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import React, { ErrorInfo, ReactNode } from 'react'
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+  fallback: ReactNode
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+}
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(_: Error): ErrorBoundaryState {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Example "componentStack":
+    //   in ComponentThatThrows (created by App)
+    //   in ErrorBoundary (created by App)
+    //   in div (created by App)
+    //   in App
+    // logErrorToMyService(error, info.componentStack)
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return this.props.fallback
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/tests_generated/test_all_default_parameters_off/src/components/ErrorFallback.tsx
+++ b/tests_generated/test_all_default_parameters_off/src/components/ErrorFallback.tsx
@@ -1,0 +1,17 @@
+const ErrorFallback = () => {
+  return (
+    <div className="hero min-h-screen bg-teal-400">
+      <div className="hero-content text-center rounded-lg p-6 max-w-md bg-white mx-auto">
+        <div className="max-w-md">
+          <h1 className="text-4xl">Error occured</h1>
+          <p className="py-6">
+            Please make sure to set up your environment variables correctly. Create a .env file based on .env.template and fill in the
+            required values. This controls the network and credentials for connections with Algod and Indexer.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ErrorFallback

--- a/tests_generated/test_all_default_parameters_off/src/main.tsx
+++ b/tests_generated/test_all_default_parameters_off/src/main.tsx
@@ -2,8 +2,13 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import './styles/App.css'
+import ErrorBoundary from './components/ErrorBoundary'
+import ErrorFallback from './components/ErrorFallback'
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary fallback={<ErrorFallback />}>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>,
 )

--- a/tests_generated/test_all_default_parameters_on_netlify/package-lock.json
+++ b/tests_generated/test_all_default_parameters_on_netlify/package-lock.json
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@algorandfoundation/algokit-utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-utils/-/algokit-utils-2.2.0.tgz",
-      "integrity": "sha512-xyvCjWhKNyC9uX90k2mEeqdpqWjs4o4/BnHMADaUNbqCGzghm33a3aqog+UlVqjpbpqqVNpneyPz0DlwxECpUQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-utils/-/algokit-utils-2.2.1.tgz",
+      "integrity": "sha512-LK6qm8YCDEKN5SSHLWoWB9u00LlQk4KgKm9wIRcctfP1y2up6zGLhsBYg4CDHqHe4TThg6wa/KYl7hpVlOqRSA==",
       "dependencies": {
         "algosdk": "^2.3.0",
         "algosdk2-2": "npm:algosdk@2.2.0",

--- a/tests_generated/test_all_default_parameters_on_netlify/src/components/ErrorBoundary.tsx
+++ b/tests_generated/test_all_default_parameters_on_netlify/src/components/ErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import React, { ErrorInfo, ReactNode } from 'react'
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+  fallback: ReactNode
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+}
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(_: Error): ErrorBoundaryState {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Example "componentStack":
+    //   in ComponentThatThrows (created by App)
+    //   in ErrorBoundary (created by App)
+    //   in div (created by App)
+    //   in App
+    // logErrorToMyService(error, info.componentStack)
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return this.props.fallback
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/tests_generated/test_all_default_parameters_on_netlify/src/components/ErrorFallback.tsx
+++ b/tests_generated/test_all_default_parameters_on_netlify/src/components/ErrorFallback.tsx
@@ -1,0 +1,17 @@
+const ErrorFallback = () => {
+  return (
+    <div className="hero min-h-screen bg-teal-400">
+      <div className="hero-content text-center rounded-lg p-6 max-w-md bg-white mx-auto">
+        <div className="max-w-md">
+          <h1 className="text-4xl">Error occured</h1>
+          <p className="py-6">
+            Please make sure to set up your environment variables correctly. Create a .env file based on .env.template and fill in the
+            required values. This controls the network and credentials for connections with Algod and Indexer.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ErrorFallback

--- a/tests_generated/test_all_default_parameters_on_netlify/src/main.tsx
+++ b/tests_generated/test_all_default_parameters_on_netlify/src/main.tsx
@@ -2,8 +2,13 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import './styles/main.css'
+import ErrorBoundary from './components/ErrorBoundary'
+import ErrorFallback from './components/ErrorFallback'
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary fallback={<ErrorFallback />}>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>,
 )

--- a/tests_generated/test_all_default_parameters_on_vercel/package-lock.json
+++ b/tests_generated/test_all_default_parameters_on_vercel/package-lock.json
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@algorandfoundation/algokit-utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-utils/-/algokit-utils-2.2.0.tgz",
-      "integrity": "sha512-xyvCjWhKNyC9uX90k2mEeqdpqWjs4o4/BnHMADaUNbqCGzghm33a3aqog+UlVqjpbpqqVNpneyPz0DlwxECpUQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-utils/-/algokit-utils-2.2.1.tgz",
+      "integrity": "sha512-LK6qm8YCDEKN5SSHLWoWB9u00LlQk4KgKm9wIRcctfP1y2up6zGLhsBYg4CDHqHe4TThg6wa/KYl7hpVlOqRSA==",
       "dependencies": {
         "algosdk": "^2.3.0",
         "algosdk2-2": "npm:algosdk@2.2.0",

--- a/tests_generated/test_all_default_parameters_on_vercel/src/components/ErrorBoundary.tsx
+++ b/tests_generated/test_all_default_parameters_on_vercel/src/components/ErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import React, { ErrorInfo, ReactNode } from 'react'
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+  fallback: ReactNode
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+}
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(_: Error): ErrorBoundaryState {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Example "componentStack":
+    //   in ComponentThatThrows (created by App)
+    //   in ErrorBoundary (created by App)
+    //   in div (created by App)
+    //   in App
+    // logErrorToMyService(error, info.componentStack)
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return this.props.fallback
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/tests_generated/test_all_default_parameters_on_vercel/src/components/ErrorFallback.tsx
+++ b/tests_generated/test_all_default_parameters_on_vercel/src/components/ErrorFallback.tsx
@@ -1,0 +1,17 @@
+const ErrorFallback = () => {
+  return (
+    <div className="hero min-h-screen bg-teal-400">
+      <div className="hero-content text-center rounded-lg p-6 max-w-md bg-white mx-auto">
+        <div className="max-w-md">
+          <h1 className="text-4xl">Error occured</h1>
+          <p className="py-6">
+            Please make sure to set up your environment variables correctly. Create a .env file based on .env.template and fill in the
+            required values. This controls the network and credentials for connections with Algod and Indexer.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ErrorFallback

--- a/tests_generated/test_all_default_parameters_on_vercel/src/main.tsx
+++ b/tests_generated/test_all_default_parameters_on_vercel/src/main.tsx
@@ -2,8 +2,13 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import './styles/main.css'
+import ErrorBoundary from './components/ErrorBoundary'
+import ErrorFallback from './components/ErrorFallback'
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary fallback={<ErrorFallback />}>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>,
 )


### PR DESCRIPTION
# Proposed changes

- Adding simple stock error boundary component from react docs 
- Adding simple fallback component with instructions on setting the .env variables to explicitly specify the algo network clients credentials

# Further notes

We should update repo setting to disallow pushes to main, i had to revert an accidental commit with these changes that went to main instead of the `react-error-boundary` branch.